### PR TITLE
Add desktop version of the notifier

### DIFF
--- a/rpilocator-rss-desktop.py
+++ b/rpilocator-rss-desktop.py
@@ -1,6 +1,11 @@
 import feedparser
 import time
 from plyer import notification
+import ssl
+
+# Since the feed is using a self-signed certificate, we need to disable SSL verification
+# to prevent the script from throwing an error.
+ssl._create_default_https_context = ssl._create_unverified_context
 
 # Feed URL
 FEED_URL = 'https://rpilocator.com/feed/'
@@ -10,10 +15,11 @@ USER_AGENT = 'xlocator feed alert'
 
 print("Starting rpilocator-rss-desktop.py...")
 
-def notifyUser():
+# Noitfy the user about a new entry
+def notifyUser(user_message = 'The stock has been updated!'):
     notification.notify(
         title='Rpilocator Alert',
-        message='The stock has been updated!',
+        message=user_message,
         app_icon=None,
         timeout=10
     )
@@ -28,8 +34,10 @@ f = feedparser.parse(FEED_URL, agent=USER_AGENT)
 if f.entries:
     for entries in f.entries:
         control.append(entries.id)
+else:
+    print("No entries in feed.")
 
-#Only wait 30 seconds after initial run.
+# Only wait 30 seconds after initial run.
 print("Initial run. Waiting 30 seconds...")
 time.sleep(30)
 
@@ -38,14 +46,20 @@ while True:
     # Fetch the feed again, and again, and again...
     f = feedparser.parse(FEED_URL, agent=USER_AGENT)
 
-    # Compare feed entries to control list.
-    # If there are new entries, send a message/push
-    # and add the new entry to control variable
     for entry in f.entries:
         if entry.id not in control:
-            notifyUser()
+
+            # Set the message to the title of the entry
+            message = entry.title
+
+            # Duplicate the message to the console
+            print(message)
+
+            # Notify the user
+            notifyUser(message)
 
             # Add entry guid to the control variable
             control.append(entry.id)
 
+    # Wait 59 seconds before checking the feed again
     time.sleep(59)

--- a/rpilocator-rss-desktop.py
+++ b/rpilocator-rss-desktop.py
@@ -1,0 +1,51 @@
+import feedparser
+import time
+from plyer import notification
+
+# Feed URL
+FEED_URL = 'https://rpilocator.com/feed/'
+
+# User Agent
+USER_AGENT = 'xlocator feed alert'
+
+print("Starting rpilocator-rss-desktop.py...")
+
+def notifyUser():
+    notification.notify(
+        title='Rpilocator Alert',
+        message='The stock has been updated!',
+        app_icon=None,
+        timeout=10
+    )
+
+# Set control to blank list
+control = []
+
+# Fetch the feed
+f = feedparser.parse(FEED_URL, agent=USER_AGENT)
+
+# If there are entries in the feed, add entry guid to the control variable
+if f.entries:
+    for entries in f.entries:
+        control.append(entries.id)
+
+#Only wait 30 seconds after initial run.
+print("Initial run. Waiting 30 seconds...")
+time.sleep(30)
+
+while True:
+    print("Checking feed...")
+    # Fetch the feed again, and again, and again...
+    f = feedparser.parse(FEED_URL, agent=USER_AGENT)
+
+    # Compare feed entries to control list.
+    # If there are new entries, send a message/push
+    # and add the new entry to control variable
+    for entry in f.entries:
+        if entry.id not in control:
+            notifyUser()
+
+            # Add entry guid to the control variable
+            control.append(entry.id)
+
+    time.sleep(59)


### PR DESCRIPTION
This PR adds a desktop version of the notifier for those, who are not using ntfy, gotify, etc. This version utilises Plyer library to send the notification. It appears as a typical notification message sent by the system. It is also quite configurable by letting the user to set the timeout (time the notification stays on the screen), type of the message and a particular icon if desired. 

N.B. I had to evade SSL verification in order to make it work. It is typically not a safe option, but in this case it should work without a flaw. The program is fully tested and did show the expected notifications when new entries appeared.